### PR TITLE
Remove a few more files from our emscripten package, to better match upstream behaviour

### DIFF
--- a/emscripten.proj
+++ b/emscripten.proj
@@ -4,18 +4,20 @@
       <EmscriptenFiles Include="$(ProjectDir)**" />
       <EmscriptenFiles Remove="$(ProjectDir)\artifacts\**" />
       <EmscriptenFiles Remove="$(ProjectDir)\eng\**" />
-      <EmscriptenFiles Remove="$(ProjectDir)\.gitignore" />
-      <EmscriptenFiles Remove="$(ProjectDir)\.gitmodules" />
+      <EmscriptenFiles Remove="$(ProjectDir)\.*" />
       <EmscriptenFiles Remove="$(ProjectDir)\build.*" />
       <EmscriptenFiles Remove="$(ProjectDir)\emscripten.proj" />
       <EmscriptenFiles Remove="$(ProjectDir)\global.json" />
       <EmscriptenFiles Remove="$(ProjectDir)\Directory.Build.*" />
+      <EmscriptenFiles Remove="$(ProjectDir)\Makefile" />
       <EmscriptenFiles Remove="$(ProjectDir)\NuGet.config" />
       <EmscriptenFiles Remove="$(ProjectDir)\.circleci\**" />
       <EmscriptenFiles Remove="$(ProjectDir)\.dotnet\**" />
       <EmscriptenFiles Remove="$(ProjectDir)\.git\**" />
-      <EmscriptenFiles Remove="$(ProjectDir)\.github\**" />
       <EmscriptenFiles Remove="$(ProjectDir)\.packages\**" />
+      <EmscriptenFiles Remove="$(ProjectDir)\site\**" />
+      <EmscriptenFiles Remove="$(ProjectDir)\**\*.pyc" />
+      <EmscriptenFiles Include="$(ProjectDir)\.emscripten" />
     </ItemGroup>
    <Copy SourceFiles="@(EmscriptenFiles)"
       DestinationFiles="@(EmscriptenFiles->'$(EmscriptenInstallDir)\%(RecursiveDir)%(Filename)%(Extension)')" />

--- a/emscripten.proj
+++ b/emscripten.proj
@@ -17,7 +17,6 @@
       <EmscriptenFiles Remove="$(ProjectDir)\.packages\**" />
       <EmscriptenFiles Remove="$(ProjectDir)\site\**" />
       <EmscriptenFiles Remove="$(ProjectDir)\**\*.pyc" />
-      <EmscriptenFiles Include="$(ProjectDir)\.emscripten" />
     </ItemGroup>
    <Copy SourceFiles="@(EmscriptenFiles)"
       DestinationFiles="@(EmscriptenFiles->'$(EmscriptenInstallDir)\%(RecursiveDir)%(Filename)%(Extension)')" />


### PR DESCRIPTION
Also purge all .pyc files, to closer match what upstream _should_ be doing.

Why do they ship .pyc files for Python 3.8 and 3.11, when the only supported version of Python for emsdk is 3.9? Who knows!