### PR TITLE
Upgrade to V4 Arcade publishing

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
    <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
+      <PublishingVersion>4</PublishingVersion>
    </PropertyGroup>
 </Project>

--- a/eng/azure-pipelines-public.yml
+++ b/eng/azure-pipelines-public.yml
@@ -23,7 +23,6 @@ stages:
     parameters:
       enablePublishBuildArtifacts: true
       enablePublishBuildAssets: true
-      enablePublishUsingPipelines: true
       jobs:
 
       ############ LINUX BUILD ############

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -47,11 +47,12 @@ extends:
         parameters:
           enablePublishBuildArtifacts: true
           enablePublishBuildAssets: true
-          enablePublishUsingPipelines: true
+          publishingVersion: 4
           jobs:
 
           ############ LINUX BUILD ############
           - job: Build_Linux
+            enablePublishing: true
             displayName: Linux
             timeoutInMinutes: 360
             pool:
@@ -85,6 +86,7 @@ extends:
     ############ POST BUILD ARCADE LOGIC ############
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:
+        publishingInfraVersion: 4
         enableSourceLinkValidation: false
         enableSigningValidation: false
         enableSymbolValidation: false

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -24,6 +24,5 @@ variables:
     - group: DotNet-HelixApi-Access
     - name: _InternalBuildArgs
       value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-        /p:DotNetPublishUsingPipelines=true
         /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)


### PR DESCRIPTION
Related to dotnet/arcade#16697.

This updates the repo from Arcade V3 publishing to V4 by:
- setting PublishingVersion to 4
- switching pipeline jobs to V4 publishingVersion/enablePublishing
- removing legacy V3 publish toggles