### PR TITLE
Disable building bullet port

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -96,7 +96,8 @@ MINIMAL_TASKS = [
     'libunwind-legacyexcept',
     'libunwind-wasmexcept',
     'libnoexit',
-    'bullet',
+    # DOTNET: disable bullet
+    #'bullet',
     # DOTNET: disable stb_image
     # 'libstb_image',
     'libwasmfs_no_fs',


### PR DESCRIPTION
We don't need it for dotnet wasm and it includes some files flagged by scanning tools