### PR TITLE
[dotnet/release/8.0] Remove sqlite from the MINIMAL embuilder list

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -66,8 +66,9 @@ MINIMAL_TASKS = [
     'crt1_proxy_main',
     'libunwind-except',
     'libnoexit',
-    'sqlite3',
-    'sqlite3-mt',
+# dotnet change, remove it, so that we don't download the sqlite3 source code in emsdk
+#    'sqlite3',
+#    'sqlite3-mt',
 ]
 
 # Additional tasks on top of MINIMAL_TASKS that are necessary for PIC testing on


### PR DESCRIPTION
Backport of #69 to dotnet/release/8.0