### PR TITLE
Remove Publish-Build-Assets variable group from dotnet/main

### DIFF
--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -17,7 +17,6 @@ variables:
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - name: _SignType
       value: real
-    # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
     - group: DotNet-HelixApi-Access
     - name: _InternalBuildArgs

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -19,7 +19,6 @@ variables:
       value: real
     # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
-    - group: Publish-Build-Assets
     - group: DotNet-HelixApi-Access
     - name: _InternalBuildArgs
       value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `eng/common-variables.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131