### PR TITLE
Add a GitHub-backed CodeQL pipeline

### DIFF
--- a/eng/azure-pipelines-github-codeql.yml
+++ b/eng/azure-pipelines-github-codeql.yml
@@ -1,0 +1,84 @@
+# Create this pipeline in `dnceng/internal` against the GitHub repository
+# `dotnet/emscripten` so GitHub-attributed CodeQL snapshots stay separate from
+# the existing ADO-mirror pipeline in `eng/azure-pipelines.yml`.
+# After merge, create or update that ADO definition to point to this file and
+# queue one `dotnet/main` run to seed the initial GitHub-attributed snapshots.
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - dotnet/main
+
+pr: none
+
+schedules:
+- cron: 0 0 * * 0
+  displayName: Weekly CodeQL refresh
+  branches:
+    include:
+    - dotnet/main
+  always: true
+
+variables:
+- template: /eng/common-variables.yml@self
+- template: /eng/common/templates-official/variables/pool-providers.yml@self
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    sdl:
+      codeql:
+        compiled:
+          enabled: true
+        runSourceLanguagesInSourceAnalysis: true
+        sourceLanguages: javascript, python
+        binaryLanguages: csharp, cpp
+      sourceAnalysisPool:
+        name: $(DncEngInternalBuildPool)
+        image: 1es-windows-2022
+        os: windows
+    containers:
+      crossamd64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-amd64
+    stages:
+    - stage: build
+      displayName: CodeQL
+      jobs:
+      - template: /eng/common/templates-official/jobs/jobs.yml@self
+        parameters:
+          jobs:
+
+          ############ LINUX BUILD ############
+          - job: Build_Linux
+            displayName: Linux
+            timeoutInMinutes: 360
+            pool:
+              name: $(DncEngInternalBuildPool)
+              image: build.azurelinux.3.amd64
+              os: linux
+            container: crossamd64
+            steps:
+            - script: |
+                git clean -ffdx
+                git reset --hard HEAD
+              displayName: Clean up working directory
+
+            - bash: |
+                cd eng/
+                echo 'int main() { return 42; }' > helloworld.cpp
+                clang -fuse-ld=lld helloworld.cpp -o helloworld
+              displayName: Run cpp helloworld
+
+            - bash: |
+                ./build.sh --ci --restore --build --pack --arch x64 --configuration $(_BuildConfig) $(_InternalBuildArgs) /p:RestoreUsingNuGetTargets=false
+              displayName: Build and package
+              env:
+                ROOTFS_DIR: /crossrootfs/x64


### PR DESCRIPTION
Summary
- add `eng/azure-pipelines-github-codeql.yml` for a GitHub-backed `dnceng/internal` CodeQL pipeline definition
- keep `eng/azure-pipelines.yml` unchanged so ADO attribution stays on `ado:dnceng/internal/dotnet-emscripten`
- reuse the existing Linux build flow so CodeQL can compile `cpp` and `csharp`, while source analysis covers `javascript` and `python`

Validation
- `ruby -e 'require "yaml"; YAML.load_file("eng/azure-pipelines-github-codeql.yml")'`
- `git diff --check`
- `clang eng/helloworld.cpp -o eng/helloworld`
- `./build.sh --ci --restore --build --pack --arch x64 --configuration Release /p:RestoreUsingNuGetTargets=false`

Post-merge
- create or update a `dnceng/internal` ADO pipeline definition against `https://github.com/dotnet/emscripten` that points to `eng/azure-pipelines-github-codeql.yml`
- queue one `dotnet/main` run after the definition exists so the initial GitHub-attributed snapshots are produced
- keep the existing ADO mirror coverage on `eng/azure-pipelines.yml`, which is already running in `https://dev.azure.com/dnceng/internal/_build/results?buildId=3041882`
