### PR TITLE
Fix unused template errors with LLVM 23

### DIFF
--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_flag_parser.h
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_flag_parser.h
@@ -189,8 +189,8 @@ class FlagParser {
 };
 
 template <typename T>
-static void RegisterFlag(FlagParser *parser, const char *name, const char *desc,
-                         T *var) {
+void RegisterFlag(FlagParser *parser, const char *name, const char *desc,
+                  T *var) {
   FlagHandler<T> *fh = new (GetGlobalLowLevelAllocator()) FlagHandler<T>(var);
   parser->RegisterHandler(name, fh, desc);
 }

--- a/system/lib/llvm-openmp/src/kmp_dispatch.h
+++ b/system/lib/llvm-openmp/src/kmp_dispatch.h
@@ -291,8 +291,8 @@ template <typename T> kmp_uint32 __kmp_eq(T value, T checker) {
     TODO: make inline function (move to header file for icl)
 */
 template <typename UT>
-static UT __kmp_wait(volatile UT *spinner, UT checker,
-                     kmp_uint32 (*pred)(UT, UT) USE_ITT_BUILD_ARG(void *obj)) {
+UT __kmp_wait(volatile UT *spinner, UT checker,
+              kmp_uint32 (*pred)(UT, UT) USE_ITT_BUILD_ARG(void *obj)) {
   // note: we may not belong to a team at this point
   volatile UT *spin = spinner;
   UT check = checker;


### PR DESCRIPTION
LLVM 23 enables `-Wunused-template`, which causes the system library build to fail because two header-defined function templates have internal linkage.

This applies the changes from emscripten-core/emscripten#27289:

- Remove `static` from `RegisterFlag` in compiler-rt.
- Remove `static` from `__kmp_wait` in llvm-openmp.

These changes are needed for the LLVM dependency update in dotnet/dotnet#8206.

> [!NOTE]
> This pull request was prepared with GitHub Copilot.