### PR TITLE
Report GitHub identity for Emscripten CodeQL uploads

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -10,6 +10,13 @@ pr: none
 variables:
 - template: /eng/common-variables.yml@self
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
+- ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.Repository.Name'], 'dotnet-emscripten')) }}:
+  - name: Codeql.ADO.Build.Repository.Provider
+    value: GitHub
+  - name: Codeql.ADO.Build.Repository.Uri
+    value: https://github.com/dotnet/emscripten
+  - name: Codeql.ADO.Build.SourceBranchName
+    value: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
 
 resources:
   repositories:


### PR DESCRIPTION
## Description

Report CodeQL uploads under the GitHub repository instead of the internal ADO mirror.
